### PR TITLE
Fix typos with Eclipse

### DIFF
--- a/docs/xtext_eclipse.md
+++ b/docs/xtext_eclipse.md
@@ -1,6 +1,6 @@
 # Xtext and Eclipse
 
-Xtext is integrated in Eclispe.
+Xtext is integrated in Eclipse.
 To run this tutorial (using Xtext) you need to install Eclipse with the 
 appropriate plugins.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
     - {'Scoping':'xtext_scoping.md'}
     - {'Modularization':'xtext_modularization.md'}
     - {'Deploy a command line version':'xtext_deploy_command_line.md'}
-    - {'Deploy an eclispe plugin':'xtext_deploy_plugin.md'}
+    - {'Deploy an Eclipse plugin':'xtext_deploy_plugin.md'}
     - {'Xtext HOWTOs':'xtext_howtos.md'}
  - TextX:
     - {'TextX Intro':'textx_intro.md'}


### PR DESCRIPTION
Sorry for this silly PR, but I've just saw a few typos with "Eclipse" <-> "Eclispe".

Thanks for these docs! :)